### PR TITLE
Change CountDifficultStrains curve to account for total strain count.

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
@@ -71,7 +71,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
             double consistentTopStrain = Difficulty / 10; // What would the top strain be if all strain values were identical
             // Use a weighted sum of all strains. Constants are arbitrary and give nice values
-            return ObjectStrains.Sum(s => 1.1 / (1 + Math.Exp(-10 * (s / consistentTopStrain - 0.88))));
+
+            double totalStrains = ObjectStrains.Count;
+            double rateOfChange = 10 + 13000.0 / totalStrains;
+            return ObjectStrains.Sum(s => 1.1 / (1 + Math.Exp(-10 * (s / consistentTopStrain - 0.86 - (rateOfChange / totalStrains)))));
         }
 
         public static double DifficultyToPerformance(double difficulty) => Math.Pow(5.0 * Math.Max(1.0, difficulty / 0.0675) - 4.0, 3.0) / 100000.0;


### PR DESCRIPTION
Changes to the CountDifficultStrains curve to account for total strain count. The goal of said change is to make the curve less lenient on very short maps and more lenient on longer ones, meaning the requirement for a strain to be difficult and be added is much higher when the object count is low. 

Desmos of the new curve and its parameters [here](https://www.desmos.com/calculator/n04de30rde).