### PR TITLE
More balance and new curve concept

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
@@ -73,8 +73,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             // Use a weighted sum of all strains. Constants are arbitrary and give nice values
 
             double totalStrains = ObjectStrains.Count;
-            double rateOfChange = 50 + 15000.0 / totalStrains;
-            return ObjectStrains.Sum(s => 1.1 / (1 + Math.Exp(-10 * (s / consistentTopStrain - 0.88 - (rateOfChange / totalStrains)))));
+            double rateOfChange = 1.064/(1 + Math.Exp(totalStrains / 518.0)) - 0.0422 * Math.Log(totalStrains) + 0.368;
+            return ObjectStrains.Sum(s => (1.1 - rateOfChange)/ (1 + Math.Exp(-10 * (s / consistentTopStrain - 0.88 - rateOfChange/4.0))));
         }
 
         public static double DifficultyToPerformance(double difficulty) => Math.Pow(5.0 * Math.Max(1.0, difficulty / 0.0675) - 4.0, 3.0) / 100000.0;


### PR DESCRIPTION
Changed the curve to reduce the worth of top strains depending on how short the map is, while also moving slightly to consider less strains. Fixes the issue of extremely short maps having 0 strain although it may still be too low in some cases. As a result extremely short maps such as padoru and brazil are buffed slightly, but maps such as wizard's tower are properly nerfed. Values over 1500 objects seems unchanged. 

[New desmos](https://www.desmos.com/calculator/zw51xzn878)